### PR TITLE
Add async functionality

### DIFF
--- a/kraken-io.gemspec
+++ b/kraken-io.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport')
   s.add_development_dependency('rspec')
   s.add_development_dependency('webmock', '~> 1.17')
+  s.add_development_dependency('pry')
+  s.add_development_dependency('pry-byebug')
 end

--- a/lib/kraken-io.rb
+++ b/lib/kraken-io.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'httparty'
 require 'active_support/hash_with_indifferent_access'
 require 'active_support/core_ext/hash'
+require 'thread'
 
 require 'kraken-io/http_multi_part'
 require 'kraken-io/response'
@@ -20,27 +21,63 @@ module Kraken
       @api_secret = options.fetch(:api_secret)
     end
 
+    def async
+      @async = true
+      self
+    end
+
+    def sync
+      @async = false
+      self
+    end
+
     def url(url, params = {})
       params = normalized_params(params).merge!(auth_hash)
       params[:url] = url
-      res = self.class.post('/url', body: params.to_json)
-      res = Kraken::Response.new(res)
-      yield res if block_given? or return res
+      call_kraken do
+        res = self.class.post('/url', body: params.to_json)
+        res = Kraken::Response.new(res)
+        yield res if block_given? or return res
+      end
+    end
+
+    def callback_url(url)
+      @callback_url = url
+      self
     end
 
     def upload(file_name, params = {})
       params = normalized_params(params).merge!(auth_hash)
-      res = self.class.multipart_post('/upload', file: file_name, body: params.to_json)
-      res = Kraken::Response.new(res)
-      yield res if block_given? or return res
+      call_kraken do
+        res = self.class.multipart_post('/upload', file: file_name, body: params.to_json)
+        res = Kraken::Response.new(res)
+        yield res if block_given? or return res
+      end
     end
 
     private
+    def call_kraken(&block)
+      if @async
+        call_async(&block)
+      else
+        yield
+      end
+    end
+
+    def call_async(&block)
+      Thread.abort_on_exception = false
+      Thread.new do |t|
+        block.call
+      end
+      nil
+    end
 
     def normalized_params(params)
       params = params.with_indifferent_access
 
-      unless params.keys.include?(:callback)
+      if params.keys.include?(:callback_url) || @callback_url
+        params[:callback_url] = @callback_url
+      else
         params[:wait] = true
       end
 

--- a/spec/kraken-io_spec.rb
+++ b/spec/kraken-io_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'timeout'
 
 describe Kraken::API do
   let(:result) do
@@ -18,6 +19,58 @@ describe Kraken::API do
     it 'is an error to leave out the key or secret' do
       expect { Kraken::API.new(api_secret: 2) }.to raise_error KeyError
       expect { Kraken::API.new(api_key: 2) }.to raise_error KeyError
+    end
+  end
+
+  describe '#async' do
+    let(:expected_params) do
+      {
+          'wait' => true,
+          'auth' => { 'api_key' => 1, 'api_secret' => 2},
+          'url' => 'http://farts.gallery',
+      }
+    end
+
+    it 'returns the result eventually' do
+      stub_request(:post, "https://api.kraken.io/v1/url")
+        .with(:body => expected_params.to_json).to_return(body: result.to_json)
+
+      defer = nil
+      immediate = subject.async.url('http://farts.gallery') do |result|
+        defer = result.kraked_url
+      end
+
+      expect(immediate).to be_nil
+
+      Timeout.timeout(2) do
+        loop until defer
+      end
+
+      expect(defer).to eq result['kraked_url']
+    end
+  end
+
+  describe '#callback' do
+    let(:expected_params) do
+      {
+        'callback_url' => 'http://seriouslylike.omg',
+        'auth' => { 'api_key' => 1, 'api_secret' => 2},
+        'url' => 'http://farts.gallery'
+      }
+    end
+
+    let(:result) do
+      {
+        "id" => "18fede37617a787649c3f60b9f1f280d"
+      }
+    end
+
+    it 'uses the call back and runs async' do
+      stub_request(:post, "https://api.kraken.io/v1/url")
+        .with(:body => expected_params.to_json).to_return(body: result.to_json)
+
+      res = subject.callback_url('http://seriouslylike.omg').url('http://farts.gallery')
+      expect(res.code).to eq 200
     end
   end
 


### PR DESCRIPTION
Add the ability for Kraken to be called asynchronously.

If you call `async` on the `Kraken::Client` object any further calls to the service will be execute asynchronously.  A block passed to the `url` or `filename` method will be yielded the response object from Kraken. To revert back to synchronous calls you can invoke the `sync` method.

Also, adds the `callback_url` convenience method, which will set a callback url for all further invocations of the service from a given client.

This shouldn't break any backward compatibility - it just adds the fluent style interface to the client - making it easier to queue up a bunch of images with identical settings in a "fire and forget" way.
