### PR TITLE
Update README to display data['message'] instead of data['error']

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ data = kraken.url(params)
 if data['success']
     puts 'Success! Optimized image URL: ' + response['kraked_url']
 else
-    puts 'Fail. Error message: ' + data['error']
+    puts 'Fail. Error message: ' + data['message']
 end
 ````
 
@@ -201,7 +201,7 @@ data = kraken.upload(params)
 if data['success']
     puts 'Success! Optimized image URL: ' + response['kraked_url']
 else
-    puts 'Fail. Error message: ' + data['error']
+    puts 'Fail. Error message: ' + data['message']
 end
 ````
 
@@ -253,7 +253,7 @@ data = kraken.upload(params)
 if data['success']
     puts 'Success! Optimized image URL: ' + response['kraked_url']
 else
-    puts 'Fail. Error message: ' + data['error']
+    puts 'Fail. Error message: ' + data['message']
 end
 ````
 
@@ -321,7 +321,7 @@ data = kraken.upload(params)
 if data['success']
     puts 'Success! Optimized image URL: ' + response['kraked_url']
 else
-    puts 'Fail. Error message: ' + data['error']
+    puts 'Fail. Error message: ' + data['message']
 end
 ````
 
@@ -369,7 +369,7 @@ data = kraken.upload(params)
 if data['success']
     puts 'Success! Optimized image URL: ' + response['kraked_url']
 else
-    puts 'Fail. Error message: ' + data['error']
+    puts 'Fail. Error message: ' + data['message']
 end
 ````
 


### PR DESCRIPTION
data['error'] returns nil so there is a "no implicit conversion of nil into String error"
The actual error message is contained in data['message']
